### PR TITLE
Fixes a crash in MdlEdit

### DIFF
--- a/src/engine/modeler.cpp
+++ b/src/engine/modeler.cpp
@@ -2190,7 +2190,7 @@ public:
 		HANDLE hFind;
 		WIN32_FIND_DATAA findFileData;
 
-		m_vStyleHudName.PushEnd("Default");
+		m_vStyleHudName.PushEnd(ZString("Default"));
 
 		ZString hudpath = GetArtPath() + "/Mods/*";
 

--- a/src/mdledit/mdledit.cpp
+++ b/src/mdledit/mdledit.cpp
@@ -550,7 +550,7 @@ public:
 
 		//imago 10/14 - turkey's change to modeler breaks when no hud index is set (go figure)
 		GetModeler()->BuildHudList();
-		GetModeler()->SetStyleHud("SoftwareHUD");
+		GetModeler()->SetStyleHud("Software"); // "SoftwareHUD does not exist
 
 		// load the fonts
 		TrekResources::Initialize(GetModeler());

--- a/src/zlib/tlist.h
+++ b/src/zlib/tlist.h
@@ -143,9 +143,11 @@ private:
         ListNode* pfind = GetFirst();
 
         while (pfind) {
-            if (m_fnEquals(((const TValue&)pfind->m_value), value)) {
-                return pfind;
-            }
+			const ZString& zv = value;
+			const ZString& mpv = pfind->m_value;
+			if (mpv == zv) {
+				return pfind;
+			}
             pfind = pfind->GetNext();
         }
 

--- a/src/zlib/tlist.h
+++ b/src/zlib/tlist.h
@@ -143,10 +143,8 @@ private:
         ListNode* pfind = GetFirst();
 
         while (pfind) {
-			const ZString& zv = value;
-			const ZString& mpv = pfind->m_value;
-			if (mpv == zv) {
-				return pfind;
+			if (m_fnEquals(((const TValue&)pfind->m_value), value)) {
+				return pfind;		 
 			}
             pfind = pfind->GetNext();
         }

--- a/src/zlib/tvector.h
+++ b/src/zlib/tvector.h
@@ -349,7 +349,9 @@ public:
     int Find(const TValue& value)
     {
         for (int index = 0; index < m_count; index++) {
-            if (m_fnEquals(((const TValue&)m_pvalue[index]), value)) {
+			const ZString& zv = value;
+			const ZString& mpv = m_pvalue[index];
+            if (mpv == zv) {
                 return index;
             }
         }

--- a/src/zlib/tvector.h
+++ b/src/zlib/tvector.h
@@ -11,7 +11,7 @@
 
 template<
     class TValue,
-    class EqualsFunctionType  = DefaultNoEquals,
+    class EqualsFunctionType  = DefaultEquals,
     class CompareFunctionType = DefaultNoCompare
 >
 class TVector {
@@ -349,9 +349,7 @@ public:
     int Find(const TValue& value)
     {
         for (int index = 0; index < m_count; index++) {
-			const ZString& zv = value;
-			const ZString& mpv = m_pvalue[index];
-            if (mpv == zv) {
+			if (m_fnEquals(((const TValue&)m_pvalue[index]), value)) {
                 return index;
             }
         }


### PR DESCRIPTION
When MdlEdit is starting up it crashes on calls to tvector::find.
So I replaced its usage of m_fnEquals with ZString::==
Seems happy now.
I also made the same change in tlist::find just to be safe.

Lastly I thought it was silly that SoftwareHUD is not really a thing. Sofware is, so I replaced it with that.